### PR TITLE
Change mkdir for makedirs

### DIFF
--- a/aeroo-docs
+++ b/aeroo-docs
@@ -34,7 +34,7 @@ from configparser import ConfigParser
 import sys
 from jsonrpc2 import JsonRpcApplication
 from wsgiref.simple_server import make_server
-from os import path, listdir, mkdir, stat, unlink, kill, remove
+from os import path, listdir, makedirs, stat, unlink, kill, remove
 from signal import SIGQUIT
 from threading import Thread, Event
 from time import time, sleep
@@ -262,7 +262,7 @@ def start_daemon(args):
     logger.info('Starting Aeroo DOCS process...')
     #### Prepare spool directory
     if not path.exists(args.spool_directory):
-        mkdir(args.spool_directory, mode=0o0700)
+        makedirs(args.spool_directory, mode=0o0700)
     daemon = False
     try:
         if args.no_daemon:
@@ -326,7 +326,7 @@ if hasattr(args, 'config_file') and args.config_file is not None:
         if input_var.capitalize() in ['Yes', 'Y']:
             conf_dir = path.dirname(args.config_file)
             if not path.exists(conf_dir):
-                mkdir(conf_dir, mode=0o0700)
+                makedirs(conf_dir, mode=0o0700)
             try:
                 with open(args.config_file, 'w') as cf:
                     config.write(cf)
@@ -346,7 +346,7 @@ if hasattr(args, 'log_file'):
     if not path.exists(args.log_file):
         log_dir = path.dirname(args.log_file)
         if not path.exists(log_dir):
-            mkdir(log_dir, mode=0o0700)
+            makedirs(log_dir, mode=0o0700)
     filehandler = logging.FileHandler(args.log_file)
     PRESERVE_FH.append(filehandler.stream.fileno())
     filehandler.setLevel(logging.DEBUG)


### PR DESCRIPTION
If we are working in a virtual environment, some of the directories could not exist, for instance tmp. We changed mkdir to makedir because if the directory does not exist it will be created automatically